### PR TITLE
Feat/update nodejs dependency

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,5 @@
 # Specify base image
-FROM node:21-slim
+FROM node:22-slim
 
 # Specify working directory
 WORKDIR /app

--- a/web/compose.local.yaml
+++ b/web/compose.local.yaml
@@ -4,7 +4,7 @@ version: "3.9"
 
 services:
     app:
-        image: node:21-slim
+        image: node:22-slim
         command: npm run dev -- -o
         environment:
             HOST: 0.0.0.0


### PR DESCRIPTION
I have faced error while instaling nuxtJS:

> npm error code EACCES
> npm error syscall mkdir
> npm error path /.npm
> npm error errno EACCES
> npm error
> npm error Your cache folder contains root-owned files, due to a bug in
> npm error previous versions of npm which has since been addressed.
> npm error
> npm error To permanently fix this problem, please run:
> npm error   sudo chown -R 501:20 "/.npm"

I found that in nodeJS 21 I have npm@10.5.0 and system was suggested me to update to last version @10.9.0

Last version of npm is part of last  version of node

Therefore I had updated node version from 21 to 22

